### PR TITLE
Update bucket to nasa-maap-data-store

### DIFF
--- a/maap-py library.ipynb
+++ b/maap-py library.ipynb
@@ -174,7 +174,7 @@
     "params['algo_id'] = 'agb_jaxa_demo_metrics_ubuntu'\n",
     "params['version'] = 'jaxa_analysis'\n",
     "params['inputs'] = 'granule,clip_upper_bound'\n",
-    "params['granule'] = 'https://cumulus-map-internal.s3.amazonaws.com/file-staging/nasa-map/Global_PALSAR2_PALSAR_Mosiac___1/N25E030_17_MOS_F02DAR.tar.gz'\n",
+    "params['granule'] = 'https://nasa-maap-data-store.s3.amazonaws.com/file-staging/nasa-map/Global_PALSAR2_PALSAR_Mosiac___1/N25E030_17_MOS_F02DAR.tar.gz'\n",
     "params['clip_upper_bound'] = '-15'\n",
     "params['username'] = 'eyam'\n",
     "response = maap.submitJob(**params)\n",


### PR DESCRIPTION
Note there are references to `cumulus-map-internal` in the cell outputs but those I would expect to change automatically when the notebook is run.

I tested the update s3 link exists:
```
aws s3 ls s3://nasa-maap-data-store/file-staging/nasa-map/Global_PALSAR2_PALSAR_Mosiac___1/N25E030_17_MOS_F02DAR.tar.gz
```